### PR TITLE
Update class-marketking-core-public.php

### DIFF
--- a/public/class-marketking-core-public.php
+++ b/public/class-marketking-core-public.php
@@ -751,7 +751,8 @@ class Marketkingcore_Public{
 
 	function marketking_rewrite_url(){
 		$pageid = apply_filters( 'wpml_object_id', get_option( 'marketking_stores_page_setting', 'none' ), 'post' , true);
-		$slug = get_post_field( 'post_name', $pageid );
+       		$slug = get_page_uri( $pageid );
+
 
 	    add_rewrite_rule(
 	        '^'.$slug.'/([^/]*)/?([^/]*)/?([^/]*)/?',


### PR DESCRIPTION
Fix Rewrite Rule URL.
Issue: If we setup Shop page  as a parent page for vendors-list page to get full URL like this https://domain.com/shop/vendors-list/  We will have "page not found" to access vendor profile by url like this https://domain.com/shop/vendors-list/vendorID Solution: Use page uri in Rewrite Rule