### PR TITLE
Fix Rewrite Rule URL for vendor dashboard

### DIFF
--- a/public/class-marketking-core-public.php
+++ b/public/class-marketking-core-public.php
@@ -1486,7 +1486,7 @@ class Marketkingcore_Public{
 	function marketking_rewrite_dashboard_url() {
 
 		$pageid = apply_filters( 'wpml_object_id', get_option( 'marketking_vendordash_page_setting', 'disabled' ), 'post' , true);
-		$slug = get_post_field( 'post_name', $pageid );
+		$slug = get_page_uri ( $pageid );
 
 	    add_rewrite_rule(
 	        '^'.$slug.'/([^/]*)/?([^/]*)/?([^/]*)/?',


### PR DESCRIPTION
Issue: If we setup Shop page as a parent page for vendor-dashboard page to get full URL like this https://domain.com/shop/vendor-ldashboard/ We will have "page not found".
Solution: Use page uri in Rewrite Rule